### PR TITLE
use tslint rules for React hooks linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "rxjs-tslint-rules": "^4.23.0",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react": "^4.0.0"
+    "tslint-react": "^4.0.0",
+    "tslint-react-hooks": "^2.1.0"
   },
   "devDependencies": {
     "@sourcegraph/prettierrc": "^2.2.0",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint:recommended", "rxjs-tslint-rules", "tslint-react", "tslint-config-prettier"],
+  "extends": ["tslint:recommended", "rxjs-tslint-rules", "tslint-react", "tslint-config-prettier", "tslint-react-hooks"],
   "rules": {
     "adjacent-overload-signatures": true,
     "array-type": [true, "array"],
@@ -154,6 +154,7 @@
     "typedef": [true, "call-signature"],
     "unified-signatures": true,
     "unnecessary-else": true,
-    "variable-name": [true, "ban-keywords"]
+    "variable-name": [true, "ban-keywords"],
+    "react-hooks-nesting": "error"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,11 @@ tslint-config-prettier@^1.18.0:
   resolved "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
 
+tslint-react-hooks@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslint-react-hooks/-/tslint-react-hooks-2.1.0.tgz#cc9841da0cef20d3527c8d16412f029c33767898"
+  integrity sha512-ccjyguEHGEU5rXikLDaQ6kT1AVo3C0HV8gi2MIJc7SbYAXjbzJkpbs4IXulgfqdEY1T6RnNSuGhyXg+2jTm5Bg==
+
 tslint-react@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-4.0.0.tgz#b4bb4c01c32448cb14d23f143a2f5e4989bb961e"


### PR DESCRIPTION
Uses https://github.com/Gelio/tslint-react-hooks for linting React hooks code to find common mistakes, as recommended by https://reactjs.org/docs/hooks-rules.html.

Addresses https://github.com/sourcegraph/sourcegraph/pull/3392#discussion_r275895266.

Note: We plan to switch from TSLint to ESLint soon (https://github.com/sourcegraph/sourcegraph/issues/2461). In that case, we will use the more standard ESLint rules for React hooks instead.

Confirmed working; if I add a `useEffect` in an if-statement, it reports:

```
/home/sqs/src/github.com/sourcegraph/sourcegraph/shared/src/components/linkPreviews/WithLinkPreviews.tsx:27:9
ERROR: 27:9     react-hooks-nesting               A hook cannot appear inside an if statement
```