### PR TITLE
allow submodule import of react-hot-loader/root

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -112,7 +112,8 @@
         "@storybook/addon-links/register",
         "mz",
         "monaco-editor/esm/vs/editor/editor.api",
-        "react-test-renderer/shallow"
+        "react-test-renderer/shallow",
+        "react-hot-loader/root"
       ]
     },
     "no-trailing-whitespace": true,


### PR DESCRIPTION
Requested at https://github.com/sourcegraph/sourcegraph/pull/3961#discussion_r283327799.

Importing this submodule is the documented and recommended (and only) way: https://github.com/gaearon/react-hot-loader#getting-started.